### PR TITLE
家財整理ページに生前整理等追加

### DIFF
--- a/app/assets/stylesheets/_cleaning.scss
+++ b/app/assets/stylesheets/_cleaning.scss
@@ -1,5 +1,5 @@
 @media screen and (min-width: 1024px) {
-  .cleaning_main {
+  .service_main {
     margin-top: 6.1rem;
 
     &__photo {
@@ -25,7 +25,7 @@
     }
   }
 
-  .cleaning_contents {
+  .service_contents {
     max-width: 1200px;
     margin: 2rem auto;
 
@@ -70,7 +70,7 @@
   //生前整理版テキスト
       &__textbox_before-birth {
         position: absolute;
-        right: 10%;
+        right: 5%;
         top: 0;
 
         &__title {
@@ -204,7 +204,7 @@
     }
   }
 
-  .cleaning_area {
+  .service_area {
     margin: 70px auto;
 
     &__title {
@@ -245,7 +245,7 @@
 
 /*レスポンシブ*/
 @media screen and (max-width: 1023px) {
-  .cleaning_main {
+  .service_main {
 
     &__photo{
       width: 100%;
@@ -265,14 +265,14 @@
         flex-direction: column;
         font-size: 1rem;
         position: absolute;
-        left: 36%;
+        left: 22%;
         top: 21%;
         color:  #fff;
       }
     }
   }
 
-  .cleaning_contents {
+  .service_contents {
     max-width: 600px;
     margin: 2rem auto;
 
@@ -288,35 +288,20 @@
       flex-direction: column;
 
       &__photo {
+        max-width: 300px;
+        margin: 0 auto;
 
         img {
           width: 100%;
         }
       }
     //家財整理版テキスト
-      &__textbox_before-birth {
-        margin-top: 1rem;
-
-        &__title {
-          border-bottom: 2px solid darkorange;
-
-          span {
-            font-size: 1.5rem;
-          }
-        }
-        &__description {
-          display: none;
-        }
-        &__description_resp {
-          letter-spacing: 1px;
-        }
-      }
-    //生前整理版テキスト
       &__textbox {
         margin-top: 1rem;
 
         &__title {
           border-bottom: 2px solid darkorange;
+          text-align: center;
 
           span {
             font-size: 1.5rem;
@@ -327,6 +312,37 @@
         }
         &__description_resp {
           letter-spacing: 1px;
+          text-indent: 1rem;
+
+          p {
+            margin-top: 10px;
+            margin-bottom: 10px;
+          }
+        }
+      }
+    //生前整理版テキスト
+      &__textbox_before-birth {
+        margin-top: 1rem;
+
+        &__title {
+          border-bottom: 2px solid darkorange;
+          text-align: center;
+
+          span {
+            font-size: 1.5rem;
+          }
+        }
+        &__description {
+          display: none;
+        }
+        &__description_resp {
+          letter-spacing: 1px;
+          text-indent: 1rem;
+
+          p {
+            margin-top: 10px;
+            margin-bottom: 10px;
+          }
         }
       }
     

--- a/app/views/root/cleaning.html.haml
+++ b/app/views/root/cleaning.html.haml
@@ -1,21 +1,21 @@
 = render 'share/header'
 
-.cleaning_main
-  .cleaning_main__photo
+.service_main
+  .service_main__photo
     = image_tag "cleaning-image2.jpg"
-    .cleaning_main__photo__title
+    .service_main__photo__title
       %h2 家財整理・生前整理
 
-.cleaning_contents
-  .cleaning_contents__title
+.service_contents
+  .service_contents__title
     %h2 家財整理とは
-  .cleaning_contents__container
-    .cleaning_contents__container__photo
+  .service_contents__container
+    .service_contents__container__photo
       =image_tag "cleaning-image1.jpg"
-    .cleaning_contents__container__textbox
-      .cleaning_contents__container__textbox__title
-        %span 大きな家財も片付けます
-      .cleaning_contents__container__textbox__description
+    .service_contents__container__textbox
+      .service_contents__container__textbox__title
+        %span 家の中をスッキリさせたい
+      .service_contents__container__textbox__description
         %p
           物がどんどん増えて一度家の中を片付けたい。
         %p
@@ -35,7 +35,7 @@
         %p
           経験豊かなスタッフがしっかり仕分けしてまいります。
 
-      .cleaning_contents__container__textbox__description_resp
+      .service_contents__container__textbox__description_resp
         %p
           物がどんどん増えて一度家の中を片付けたい。
         %p
@@ -61,73 +61,97 @@
         %p
           仕分けしてまいります。
 
-  .cleaning_contents__title
+  .service_contents__title
     %h2 ご利用料金
-  -# .cleaning_contents__fee
-  -#   %p.cleaning_contents__fee__inner
+  -# .service_contents__fee
+  -#   %p.service_contents__fee__inner
   -#     %span 家財整理サービス
-  -# .cleaning_contents__price
+  -# .service_contents__price
   -#   %span 1
   -#   %span.small 日
   -#   %span ２０，０００
   -#   %span.small 円
   -#   %span.small（税別）
 
-  .cleaning_contents__title
+  .service_contents__title
     %h2 参考事例
-  .cleaning_contents__casebox
-    .cleaning_contents__casebox__inner
+  .service_contents__casebox
+    .service_contents__casebox__inner
       %h3 Aさん宅の事例
-      .cleaning_contents__casebox__inner__before
+      .service_contents__casebox__inner__before
         = image_tag "cleaning-image1.jpg"
-      .cleaning_contents__casebox__inner__after
+      .service_contents__casebox__inner__after
         = image_tag "cleaning-image2.jpg"
 
-.cleaning_contents
-  .cleaning_contents__title
+.service_contents
+  .service_contents__title
     %h2 生前整理とは
-  .cleaning_contents__container
-    .cleaning_contents__container__photo
+  .service_contents__container
+    .service_contents__container__photo
       =image_tag "cleaning-image1.jpg"
-    .cleaning_contents__container__textbox_before-birth
-      .cleaning_contents__container__textbox_before-birth__title
+    .service_contents__container__textbox_before-birth
+      .service_contents__container__textbox_before-birth__title
         %span 大きな家財も片付けます
-      .cleaning_contents__container__textbox_before-birth__description
+      .service_contents__container__textbox_before-birth__description
         %p
-          大きすぎて捨てるに捨てれない家財や
+          元気なうちに身のまわりの整理をしておきたい。
         %p
-          断捨離をしたいがどのように捨ててよいのかわからない家財などを
+          施設入所することになったので片付け荷作りなど手伝ってほしい。
         %p
-          当社にて回収し、処分させていただきます。
+          子ども達や親族、ご近所さんには迷惑かけないようにしたい。
+        %p
+          そう思うのは親心であり、大切な人のために行う。
+        %p
+          とても大切なことであります。
+        %p
+          私達はそのお気持ちに寄り添いご依頼者様のご納得のいく
+        %p
+          お手伝いをさせていただきます。
 
-      .cleaning_contents__container__textbox_before-birth__description_resp
+      .service_contents__container__textbox_before-birth__description_resp
         %p
-          大きすぎて捨てるに捨てれない家財や
+          元気なうちに身のまわりの整理を
         %p
-          断捨離をしたいがどのように捨ててよいのか
+          しておきたい。
         %p
-          わからない家財などを、
+          施設入所することになったので、片付け
         %p
-          当社にて回収し、処分させていただきます。
+          荷作りなど手伝ってほしい。
+        %p
+          子ども達や親族、ご近所さんには
+        %p
+          迷惑かけないようにしたい。
+        %p
+          そう思うのは親心であり、大切な人の
+        %p
+          ために行う。
+        %p
+          とても大切なことであります。
+        %p
+          私達はそのお気持ちに寄り添い
+        %p
+          ご依頼者様のご納得のいくお手伝いを
+        %p
+          させていただきます。
 
-  .cleaning_contents__title
+  .service_contents__title
     %h2 ご利用料金
-  -# .cleaning_contents__fee
-  -#   %p.cleaning_contents__fee__inner
+  -# .service_contents__fee
+  -#   %p.service_contents__fee__inner
   -#     %span 家財整理サービス
-  -# .cleaning_contents__price
+  -# .service_contents__price
   -#   %span 1
   -#   %span.small 日
   -#   %span ２０，０００
   -#   %span.small 円
   -#   %span.small（税別）
 
-  .cleaning_contents__title
+  .service_contents__title
     %h2 参考事例
-  .cleaning_contents__casebox
-    .cleaning_contents__casebox__inner
+  .service_contents__casebox
+    .service_contents__casebox__inner
       %h3 Bさん宅の事例
-      .cleaning_contents__casebox__inner__before
+      .service_contents__casebox__inner__before
         = image_tag "cleaning-image1.jpg"
-      .cleaning_contents__casebox__inner__after
+      .service_contents__casebox__inner__after
         = image_tag "cleaning-image2.jpg"


### PR DESCRIPTION
# What
家財整理と生前整理のサービス内容を実装

# Why
同じ種類のサービス内容をまとめて記載することで、ユーザービリティの向上をはかる

# 備考
・ご利用料金はrender予定のため空けています。
・スマホ版のヘッダー被りはヘッダーのレスポンシブ後に対応します。